### PR TITLE
Cleaning up uses of 'swap!' and 'send' in the examples.

### DIFF
--- a/Agents.md
+++ b/Agents.md
@@ -15,7 +15,7 @@ Interacting with an agent is very similar to using atoms. If we wanted to repres
 And changing the account holder:
 
 ~~~clojure
-   (send! checking-account (comp #(assoc % :holder "your-name")))
+   (send checking-account assoc :holder "your-name")
 ~~~
 
 ***

--- a/Atoms.md
+++ b/Atoms.md
@@ -46,7 +46,7 @@ If we wanted to represent what we know about Sansa Stark as an atom:
 And changing her martial status:
 
 ~~~clojure
-   (swap! checking-account (comp #(assoc % :holder "your-name")))
+   (swap! checking-account assoc :holder "your-name")
 ~~~
 
 ***


### PR DESCRIPTION
This is a more typical representation of passing functions to 'send' and 'swap!', but it might be trickier to explain.  Another option that might be more readable for students would be to use the more standard form of anonymous functions like (fn [m](assoc m :holder)) in place of the abbreviated syntax.   (and my username is probably unfamiliar, so I should mention that this is from Ted.)
